### PR TITLE
Corrected translation for disease(s) field (fixes #410)

### DIFF
--- a/src/humancellatlas/data/metadata/api.py
+++ b/src/humancellatlas/data/metadata/api.py
@@ -204,7 +204,7 @@ class DonorOrganism(Biomaterial):
         super().__init__(json)
         content = json.get('content', json)
         self.genus_species = {gs['text'] for gs in content['genus_species']}
-        self.diseases = {d['text'] for d in lookup(content, 'disease', 'diseases', default=set()) if d}
+        self.diseases = {d['text'] for d in lookup(content, 'diseases', 'disease', default=[]) if d}
         self.organism_age = content.get('organism_age')
         self.organism_age_unit = content.get('organism_age_unit', {}).get('text')
         self.sex = lookup(content, 'sex', 'biological_sex')
@@ -240,7 +240,7 @@ class SpecimenFromOrganism(Biomaterial):
         super().__init__(json)
         content = json.get('content', json)
         self.storage_method = content.get('preservation_storage', {}).get('storage_method')
-        self.diseases = {d['text'] for d in lookup(content, 'disease', 'diseases', default=set()) if d}
+        self.diseases = {d['text'] for d in lookup(content, 'diseases', 'disease', default=[]) if d}
         self.organ = content.get('organ', {}).get('text')
         self.organ_part = content.get('organ_part', {}).get('text')
 

--- a/src/humancellatlas/data/metadata/api.py
+++ b/src/humancellatlas/data/metadata/api.py
@@ -195,7 +195,7 @@ class Biomaterial(LinkedEntity):
 @dataclass(init=False)
 class DonorOrganism(Biomaterial):
     genus_species: Set[str]
-    disease: Set[str]
+    diseases: Set[str]
     organism_age: str
     organism_age_unit: str
     sex: str
@@ -204,7 +204,7 @@ class DonorOrganism(Biomaterial):
         super().__init__(json)
         content = json.get('content', json)
         self.genus_species = {gs['text'] for gs in content['genus_species']}
-        self.disease = {d['text'] for d in content.get('disease', []) if d}
+        self.diseases = {d['text'] for d in lookup(content, 'disease', 'diseases', default=set()) if d}
         self.organism_age = content.get('organism_age')
         self.organism_age_unit = content.get('organism_age_unit', {}).get('text')
         self.sex = lookup(content, 'sex', 'biological_sex')
@@ -222,11 +222,17 @@ class DonorOrganism(Biomaterial):
                       f"Use DonorOrganism.sex instead.", DeprecationWarning)
         return self.sex
 
+    @property
+    def disease(self):
+        warnings.warn(f"DonorOrganism.disease is deprecated. "
+                      f"Use DonorOrganism.diseases instead.", DeprecationWarning)
+        return self.diseases
+
 
 @dataclass(init=False)
 class SpecimenFromOrganism(Biomaterial):
     storage_method: Optional[str]
-    disease: Set[str]
+    diseases: Set[str]
     organ: Optional[str]
     organ_part: Optional[str]
 
@@ -234,9 +240,15 @@ class SpecimenFromOrganism(Biomaterial):
         super().__init__(json)
         content = json.get('content', json)
         self.storage_method = content.get('preservation_storage', {}).get('storage_method')
-        self.disease = {d['text'] for d in content.get('disease', []) if d}
+        self.diseases = {d['text'] for d in lookup(content, 'disease', 'diseases', default=set()) if d}
         self.organ = content.get('organ', {}).get('text')
         self.organ_part = content.get('organ_part', {}).get('text')
+
+    @property
+    def disease(self):
+        warnings.warn(f"SpecimenFromOrganism.disease is deprecated. "
+                      f"Use SpecimenFromOrganism.diseases instead.", DeprecationWarning)
+        return self.diseases
 
 
 @dataclass(init=False)

--- a/test/test.py
+++ b/test/test.py
@@ -34,15 +34,16 @@ class TestAccessorApi(TestCase):
         warnings.simplefilter("ignore", ResourceWarning)
 
     def test_example_bundles(self):
-        for directory, age_range, has_specimens in [
-            ('CD4+ cytotoxic T lymphocytes', AgeRange(min=567648000, max=1892160000), True),
-            ('Healthy and type 2 diabetes pancreas', AgeRange(min=1356048000, max=1356048000), True),
-            ('HPSI_human_cerebral_organoids', AgeRange(min=1419120000, max=1545264000), True),
-            ('Mouse Melanoma', AgeRange(min=3628800, max=7257600), True),
-            ('Single cell transcriptome analysis of human pancreas', AgeRange(min=662256000, max=662256000), True),
-            ('Tissue stability', AgeRange(min=1734480000, max=1892160000), False),
-            ('HPSI_human_cerebral_organoids', AgeRange(min=1419120000, max=1545264000), True),
-            ('1M Immune Cells', AgeRange(min=1639872000, max=1639872000), True)
+        for directory, age_range, diseases, has_specimens in [
+            ('CD4+ cytotoxic T lymphocytes', AgeRange(min=567648000, max=1892160000), {'normal'}, True),
+            ('Healthy and type 2 diabetes pancreas', AgeRange(min=1356048000, max=1356048000), {'normal'}, True),
+            ('HPSI_human_cerebral_organoids', AgeRange(min=1419120000, max=1545264000), {'normal'}, True),
+            ('Mouse Melanoma', AgeRange(min=3628800, max=7257600), {'subcutaneous melanoma'}, True),
+            ('Single cell transcriptome analysis of human pancreas', AgeRange(min=662256000, max=662256000), {'normal'},
+             True),
+            ('Tissue stability', AgeRange(min=1734480000, max=1892160000), {'normal'}, False),
+            ('HPSI_human_cerebral_organoids', AgeRange(min=1419120000, max=1545264000), {'normal'}, True),
+            ('1M Immune Cells', AgeRange(min=1639872000, max=1639872000), None, True)
         ]:
             with self.subTest(dir=directory):
                 manifest, metadata_files = download_example_bundle(repo='HumanCellAtlas/metadata-schema',
@@ -52,7 +53,7 @@ class TestAccessorApi(TestCase):
                 version = '2018-08-03T082009.272868Z'
                 self._assert_bundle(uuid=uuid, version=version,
                                     manifest=manifest, metadata_files=metadata_files,
-                                    age_range=age_range, has_specimens=has_specimens)
+                                    age_range=age_range, diseases=diseases, has_specimens=has_specimens)
 
     def test_bad_content(self):
         deployment, replica, uuid = 'staging', 'aws', 'df00a6fc-0015-4ae0-a1b7-d4b08af3c5a6'
@@ -88,44 +89,37 @@ class TestAccessorApi(TestCase):
                           "to have content type 'application/json', not 'bad'")
 
     def test_one_bundle(self):
-        for deployment, replica, uuid, version, age_range in [
+        for deployment, replica, uuid, version, age_range, diseases in [
             # A v5 bundle
-            (None, 'aws', 'b2216048-7eaa-45f4-8077-5a3fb4204953', None, AgeRange(min=3628800, max=7257600)),
+            (None, 'aws', 'b2216048-7eaa-45f4-8077-5a3fb4204953', None, AgeRange(min=3628800, max=7257600),
+             {'subcutaneous melanoma'}),
             # A vx primary bundle with a cell_suspension as sequencing input
-            ('staging', 'aws', '3e7c6f8e-334c-41fb-a1e5-ddd9fe70a0e2', None, None),
+            ('staging', 'aws', '3e7c6f8e-334c-41fb-a1e5-ddd9fe70a0e2', None, None, {'glioblastoma'}),
             # A vx analysis bundle for the primary bundle with a cell_suspension as sequencing input
-            ('staging', 'aws', '859a8bd2-de3c-4c78-91dd-9e35a3418972', '2018-09-20T232924.687620Z', None),
+            ('staging', 'aws', '859a8bd2-de3c-4c78-91dd-9e35a3418972', '2018-09-20T232924.687620Z', None,
+             {'glioblastoma'}),
             # A vx primary bundle with a specimen_from_organism as sequencing input
-            ('staging', 'aws', '3e7c6f8e-334c-41fb-a1e5-ddd9fe70a0e2', '2018-09-20T230221.622042Z', None),
+            ('staging', 'aws', '3e7c6f8e-334c-41fb-a1e5-ddd9fe70a0e2', '2018-09-20T230221.622042Z', None,
+             {'glioblastoma'}),
             # A bundle containing a specimen_from_organism.json with a schema version of 2.7.1
-            ('staging', 'aws', '70184761-70fc-4b80-8c48-f406a478d5ab', '2018-09-05T182535.846470Z', None),
+            ('staging', 'aws', '70184761-70fc-4b80-8c48-f406a478d5ab', '2018-09-05T182535.846470Z', None,
+             {'glioblastoma'}),
         ]:
             with self.subTest(uuid=uuid):
                 client = dss_client(deployment)
                 version, manifest, metadata_files = download_bundle_metadata(client, replica, uuid, version)
-                self._assert_bundle(uuid, version, manifest, metadata_files, age_range)
+                self._assert_bundle(uuid, version, manifest, metadata_files, age_range, diseases)
 
-    def _assert_bundle(self, uuid, version, manifest, metadata_files, age_range, has_specimens=True):
+    def _assert_bundle(self, uuid, version, manifest, metadata_files, age_range, diseases, has_specimens=True):
         bundle = Bundle(uuid, version, manifest, metadata_files)
-        expected_disease_values = {'b2216048-7eaa-45f4-8077-5a3fb4204953': {'subcutaneous melanoma'},
-                                   '3e7c6f8e-334c-41fb-a1e5-ddd9fe70a0e2.2018-09-20T232924.687620Z': {'glioblastoma'},
-                                   '3e7c6f8e-334c-41fb-a1e5-ddd9fe70a0e2': {'glioblastoma'},
-                                   '859a8bd2-de3c-4c78-91dd-9e35a3418972.2018-09-20T230221.622042Z': {'glioblastoma'},
-                                   '70184761-70fc-4b80-8c48-f406a478d5ab.2018-09-05T182535.846470Z': {'glioblastoma'}}
+        diseases = diseases or set()
         biomaterials = bundle.biomaterials.values()
-        full_uuid = f"{uuid}{f'.{version}' if version else ''}"
-        if full_uuid in expected_disease_values.keys():
-            actual_diseases = set(chain(*[getattr(bm, 'diseases', {})
-                                          for bm in biomaterials if isinstance(bm, SpecimenFromOrganism)
-                                          or isinstance(bm, DonorOrganism)]))
-            diseases_from_old_field = set(chain(*[getattr(bm, 'disease', {})
-                                                  for bm in biomaterials if isinstance(bm, SpecimenFromOrganism)
-                                                  or isinstance(bm, DonorOrganism)]))
-            self.assertEquals(actual_diseases, expected_disease_values[full_uuid])
-            self.assertEquals(actual_diseases, diseases_from_old_field)
-        else:
-            logging.warning(f'Disease value was not tested. An expected disease value was not set for Bundle {uuid}'
-                            f'with version {version}. ')
+        actual_diseases = set(chain(*[bm.diseases for bm in biomaterials
+                                      if isinstance(bm, (DonorOrganism, SpecimenFromOrganism))]))
+        diseases_from_old_field = set(chain(*[bm.disease for bm in biomaterials
+                                              if isinstance(bm, (DonorOrganism, SpecimenFromOrganism))]))
+        self.assertEquals(actual_diseases, diseases)
+        self.assertEquals(actual_diseases, diseases_from_old_field)
         self.assertEqual(str(bundle.uuid), uuid)
         self.assertEqual(bundle.version, version)
         self.assertEqual(1, len(bundle.projects))


### PR DESCRIPTION
Modified api code to assign disease values from both `disease` and `diseases` metadata fields.